### PR TITLE
Fixed multiline string parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed parsing for multiline strings with seven quotes `"""""""`.
+
 ## [1.0.0] - 2024-05-15
 
 ### Added

--- a/src/hsjson.lua
+++ b/src/hsjson.lua
@@ -458,7 +458,7 @@ local BasicStringChar = S" \n\r\t" + P"\239\187\191" + Char
 local BasicString = P'"' * g.Cs (BasicStringChar ^ 0) * (P'"' + Err "unterminated string")
 local ComplexString --= P'"""' * g.Cs (BasicStringChar ^ 0) * (P'"""' + Err "unterminated multiline string")
 do
-  -- The H2 engine only terminates multiline strings if a """ is not followed by another "
+	-- The H2 engine only terminates multiline strings if a """ is not followed by another "
 	-- """"""" means """ + " + """ so should be parsed to simply "
 	local TripleClose = P'"""' * (-P'"')
 	ComplexString = P'"""' * g.C((g.P(1) - TripleClose)^0) * P'"""'

--- a/src/hsjson.lua
+++ b/src/hsjson.lua
@@ -435,7 +435,7 @@ local MultiLineComment = P"/*" * (1 - P"*/")^0 * P"*/"
 local Space = (S" \n\r\t" + P"\239\187\191" + BasicComment + MultiLineComment)^0
 
 local PlainChar = 1 - S"\"\\\n\r"
-local SGGEscape = R("09","AZ","az") + S"_-[]" -- bad hack
+local SGGEscape = R("09","AZ","az") + S"_-[]." -- bad hack
 local EscapeSequence = P"\\" * g.C ((S"\"\\/bfnrt") / escapechars + SGGEscape)
 local HexDigit = R("09", "af", "AF")
 local function UTF16Surrogate (match, pos, high, low)
@@ -457,13 +457,11 @@ local BasicStringChar = S" \n\r\t" + P"\239\187\191" + Char
 --local ComplexStringChar = (BasicStringChar * BasicStringChar^-1) + g.Cg(P'"""','end') + (P'"' * P'"'^-1)
 local BasicString = P'"' * g.Cs (BasicStringChar ^ 0) * (P'"' + Err "unterminated string")
 local ComplexString --= P'"""' * g.Cs (BasicStringChar ^ 0) * (P'"""' + Err "unterminated multiline string")
-do -- https://www.gammon.com.au/scripts/doc.php?lua=lpeg.Cmt
-	local equals = g.P'"'
-	local open = '"' * g.Cg(equals, "init") * '"'
-	local close = '"' * g.C(equals) * '"'
-	local closeeq = g.Cmt(close * g.Cb("init"), function (s, i, a, b) return a == b end)
-	local string = open * g.C((g.P(1) - closeeq)^0) * close / 1
-	ComplexString = string
+do
+  -- The H2 engine only terminates multiline strings if a """ is not followed by another "
+	-- """"""" means """ + " + """ so should be parsed to simply "
+	local TripleClose = P'"""' * (-P'"')
+	ComplexString = P'"""' * g.C((g.P(1) - TripleClose)^0) * P'"""'
 end
 
 local Integer = P"-"^(-1) * (P"0" + (R"19" * R"09"^0))


### PR DESCRIPTION
The previous approach would parse strings like `"""""""` into an empty string and a `"` starting a new string, resulting in unterminated string errors.
This is an issue in many localization files, e.g. this error:
```
[ERROR/lua_manager.cpp:394] ...ult\ReturnOfModding\plugins\SGG_Modding-SJSON/hsjson.lua:581: Error decoding JSON at line 342, column 28: unterminated string at line 342, column 28
Line content:       DisplayName = """""""                                                                                                                                                            
stack traceback:                                                                                                                                                                                     
        [C]: in function 'error'                                                                                                                                                                     
        ...ult\ReturnOfModding\plugins\SGG_Modding-SJSON/hsjson.lua:581: in function 'decode'                                                                                                        
        ...fault\ReturnOfModding\plugins\SGG_Modding-SJSON\main.lua:43: in function <...fault\ReturnOfModding\plugins\SGG_Modding-SJSON\main.lua:42>                                                 
        (...tail calls...)                                                                                                                                                                           
        [C]: in function 'on_sjson_read_as_string'                                                                                                                                                   
        ...fault\ReturnOfModding\plugins\SGG_Modding-SJSON\main.lua:52: in function 'prepare_callbacks'                                                                                              
        ...fault\ReturnOfModding\plugins\SGG_Modding-SJSON\main.lua:130: in function 'hook'                                                                                                          
        ...kkelM-Zagreus_Journey/Game/Text/uk/MiscText.uk.sjson.lua:180: in main chunk                                                                                                               
        [C]: in function 'xpcall'                                                                                                                                                                    
        ...es\Default\ReturnOfModding\plugins\LuaENVY-ENVY\main.lua:106: in function <...es\Default\ReturnOfModding\plugins\LuaENVY-ENVY\main.lua:79>                                                
        (...tail calls...)                                                                                                                                                                           
        ...ReturnOfModding\plugins\NikkelM-Zagreus_Journey\main.lua:334: in function 'on_ready'                                                                                                      
        ...ault\ReturnOfModding\plugins\SGG_Modding-ReLoad\main.lua:21: in function <...ault\ReturnOfModding\plugins\SGG_Modding-ReLoad\main.lua:15>                                                 
        (...tail calls...)                                                                                                                                                                           
        ...ReturnOfModding\plugins\NikkelM-Zagreus_Journey\main.lua:641: in function 'callback'                                                                                                      
        ...ult\ReturnOfModding\plugins\SGG_Modding-ModUtil\main.lua:38: in function 'game'                                                                                                           
        ...ult\ReturnOfModding\plugins\SGG_Modding-ModUtil\main.lua:56: in function <...ult\ReturnOfModding\plugins\SGG_Modding-ModUtil\main.lua:54>
```

Also adds `.` to the `SGGEscape` set, as I encountered one such escape in `ShellText.de.sjson` from Hades 1.

Closes #1